### PR TITLE
共有された年賀状をShareIdで管理する

### DIFF
--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,19 +1,22 @@
 import { ImageResponse } from 'next/og'
 import { NextResponse } from 'next/server'
-import { getPublicCard } from '../../../utils/strapi/card'
+import { getSharedCard } from '../../../utils/strapi/card'
 
 export const GET = async (request: Request) => {
   const { searchParams } = new URL(request.url)
-  const cardId = searchParams.get('cardId')
+  const shareId = searchParams.get('shareId')
 
-  if (!cardId) {
+  if (!shareId) {
     return NextResponse.json(
-      { error: 'CardId parameter is required' },
+      { error: 'ShareId parameter is required' },
       { status: 400 }
     )
   }
 
-  const card = await getPublicCard(parseInt(cardId, 10))
+  const card = await getSharedCard(shareId)
+  if (!card) {
+    return NextResponse.json({ error: 'Card not found' }, { status: 404 })
+  }
 
   return new ImageResponse(
     (

--- a/src/app/link/[id]/page.tsx
+++ b/src/app/link/[id]/page.tsx
@@ -1,15 +1,15 @@
 import { redirect } from 'next/navigation'
-import { getPublicCard } from '../../../utils/strapi/card'
 import Shared from '../../../layouts/Shared'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '../../api/auth/[...nextauth]/authOptions'
+import { getSharedCard } from '../../../utils/strapi/card'
 
 export const generateMetadata = async ({
   params,
 }: {
   params: { id: string }
 }) => {
-  const card = await getPublicCard(parseInt(params.id, 10))
+  const card = await getSharedCard(params.id)
   return {
     title: `${card?.data.attributes.creatorName} さんから年賀状が届きました - あけおめリンク`,
     openGraph: {
@@ -19,9 +19,9 @@ export const generateMetadata = async ({
 }
 
 const Page = async ({ params }: { params: { id: string } }) => {
-  const card = await getPublicCard(parseInt(params.id, 10))
-  const session = await getServerSession(authOptions)
+  const card = await getSharedCard(params.id)
   if (!card) redirect('/')
+  const session = await getServerSession(authOptions)
 
   return (
     <Shared

--- a/src/layouts/Shared/index.tsx
+++ b/src/layouts/Shared/index.tsx
@@ -27,17 +27,17 @@ const Shared = ({ cardRecord, cardCreatorId, strapiUserId }: SharedProps) => {
   useEffect(() => {
     if (!strapiUserId) {
       putLocalReceivedCard({
-        cardId: cardRecord.id,
+        shareId: cardRecord.attributes.shareId,
         creatorId: cardCreatorId,
       }).then((record) => setSeed(record?.randomSeed))
     } else if (strapiUserId !== cardCreatorId) {
       addUniqueReceivedCard({
-        cardId: cardRecord.id,
+        shareId: cardRecord.attributes.shareId,
       }).then((record) => setSeed(record?.data.attributes.randomSeed))
     } else {
       setSeed(10000000 + Math.floor(Math.random() * 90000000))
     }
-  }, [cardCreatorId, cardRecord.id, strapiUserId])
+  }, [cardRecord, cardCreatorId, strapiUserId])
 
   if (!randomSeed) return null
 

--- a/src/utils/db/StrapiAdaper.tsx
+++ b/src/utils/db/StrapiAdaper.tsx
@@ -19,7 +19,7 @@ const StrapiAdaper = () => {
           )
           .map((receivedCard) =>
             addUniqueReceivedCard({
-              cardId: receivedCard.cardId,
+              shareId: receivedCard.shareId,
               randomSeed: receivedCard.randomSeed,
             })
           )

--- a/src/utils/db/index.ts
+++ b/src/utils/db/index.ts
@@ -1,53 +1,53 @@
 import Dexie, { Table } from 'dexie'
 
 export type ReceivedCard = {
-  cardId: number
+  shareId: string
   creatorId: number
   randomSeed: number
 }
 
-class Default extends Dexie {
+class AppDb extends Dexie {
   receivedCard!: Table<ReceivedCard>
 
   constructor() {
-    super('app')
+    super('app-db')
     this.version(1).stores({
-      receivedCard: 'cardId',
+      receivedCard: 'shareId',
     })
   }
 }
 
-const db = new Default()
+const db = new AppDb()
 
 export const putLocalReceivedCard = async ({
-  cardId,
+  shareId,
   creatorId,
 }: {
-  cardId: number
+  shareId: string
   creatorId: number
 }) => {
-  const existingLocalReceivedCard = await db.receivedCard.get(cardId)
+  const existingLocalReceivedCard = await db.receivedCard.get(shareId)
   if (existingLocalReceivedCard) {
     return existingLocalReceivedCard
   }
   await db.receivedCard.put({
-    cardId,
+    shareId,
     creatorId,
     randomSeed: 10000000 + Math.floor(Math.random() * 90000000),
   })
-  return await db.receivedCard.get(cardId)
+  return await db.receivedCard.get(shareId)
 }
 
-export const getLocalReceivedCard = async (cardId: number) => {
-  return await db.receivedCard.get(cardId)
+export const getLocalReceivedCard = async (shareId: string) => {
+  return await db.receivedCard.get(shareId)
 }
 
 export const getAllLocalReceivedCard = async () => {
   return await db.receivedCard.toArray()
 }
 
-export const deleteLocalReceivedCard = async (cardId: number) => {
-  await db.receivedCard.delete(cardId)
+export const deleteLocalReceivedCard = async (shareId: string) => {
+  await db.receivedCard.delete(shareId)
 }
 
 export const deleteAllLocalReceivedCard = async () => {

--- a/src/utils/strapi/card.ts
+++ b/src/utils/strapi/card.ts
@@ -22,7 +22,7 @@ export type CardAttributes = {
   publishedAt: string
   userImages: { data: StrapiRecord<MediaAttributes>[] }
   creator: { data: StrapiRecord<UserAttributes> }
-  shareId: string | null
+  shareId: string
 }
 
 export const getPrivateCard = async (id: number) => {

--- a/src/utils/strapi/card.ts
+++ b/src/utils/strapi/card.ts
@@ -22,6 +22,7 @@ export type CardAttributes = {
   publishedAt: string
   userImages: { data: StrapiRecord<MediaAttributes>[] }
   creator: { data: StrapiRecord<UserAttributes> }
+  shareId: string | null
 }
 
 export const getPrivateCard = async (id: number) => {
@@ -66,13 +67,16 @@ export const getPrivateCard = async (id: number) => {
   }
 }
 
-export const getPublicCard = async (id: number) => {
+export const getSharedCard = async (shareId: string) => {
   try {
     const strapiResponse = await fetch(
-      `${
-        process.env.NEXT_PUBLIC_STRAPI_BACKEND_URL
-      }/api/cards/${id}?${stringify({
+      `${process.env.NEXT_PUBLIC_STRAPI_BACKEND_URL}/api/cards?${stringify({
         populate: ['creator', 'userImages'],
+        filters: {
+          shareId: {
+            $eq: shareId,
+          },
+        },
       })}`,
       {
         cache: 'no-cache',
@@ -85,15 +89,20 @@ export const getPublicCard = async (id: number) => {
       return undefined
     }
 
-    const card: StrapiApiResponse<CardAttributes> = await strapiResponse.json()
+    const card: StrapiApiListResponse<CardAttributes> =
+      await strapiResponse.json()
+    if (card.data.length === 0) {
+      return undefined
+    }
+
     return {
       data: {
-        ...card.data,
+        ...card.data[0],
         attributes: {
-          ...card.data.attributes,
+          ...card.data[0].attributes,
           creator: {
             data: {
-              id: card.data.attributes.creator.data.id,
+              id: card.data[0].attributes.creator.data.id,
             },
           },
         },


### PR DESCRIPTION
- `/link` 以下にShareIdをとるように変更
- IndexedDBへの一時保存もShareIdベースに変更
  - IndexedDB経由での逆引き対策
  - DBのupgradeは逆引きの穴を残すことになるので断念して新規でDB作成