### PR TITLE
出力画像の圧縮処理

### DIFF
--- a/src/components/Card/Renderer/index.tsx
+++ b/src/components/Card/Renderer/index.tsx
@@ -55,9 +55,7 @@ const Renderer = ({
                   canvas.toBlob(
                     (blob) => {
                       if (!blob) return
-                      if (blob.size < 4718592)
-                        // 4718592 = 4.5MB Vercelの制限
-                        onRender(blob)
+                      if (blob.size < 4 * 1024 * 1024) onRender(blob)
                       else toBlob(quality === undefined ? 1 : quality * 0.9)
                     },
                     quality === undefined ? 'image/png' : 'image/jpeg',

--- a/src/components/Card/Renderer/index.tsx
+++ b/src/components/Card/Renderer/index.tsx
@@ -55,7 +55,9 @@ const Renderer = ({
                   canvas.toBlob(
                     (blob) => {
                       if (!blob) return
-                      if (blob.size < 4718592) onRender(blob)
+                      if (blob.size < 4718592)
+                        // 4718592 = 4.5MB Vercelの制限
+                        onRender(blob)
                       else toBlob(quality === undefined ? 1 : quality * 0.9)
                     },
                     quality === undefined ? 'image/png' : 'image/jpeg',

--- a/src/components/Card/Renderer/index.tsx
+++ b/src/components/Card/Renderer/index.tsx
@@ -50,9 +50,18 @@ const Renderer = ({
             // 画面内のnext/imageは全てloading=eagerにしないとハングする
             html2canvas(containerRef.current, {}).then(
               (canvas: HTMLCanvasElement) => {
-                canvas.toBlob((blob) => {
-                  if (blob) onRender(blob)
-                })
+                const toBlob = (quality?: number) => {
+                  canvas.toBlob(
+                    (blob) => {
+                      if (!blob) return
+                      if (blob.size < 4718592) onRender(blob)
+                      else toBlob(quality === undefined ? 1 : quality - 0.1)
+                    },
+                    quality === undefined ? 'image/png' : 'image/jpeg',
+                    quality
+                  )
+                }
+                toBlob()
               }
             )
             setIsRendered(true)

--- a/src/components/Card/Renderer/index.tsx
+++ b/src/components/Card/Renderer/index.tsx
@@ -51,11 +51,12 @@ const Renderer = ({
             html2canvas(containerRef.current, {}).then(
               (canvas: HTMLCanvasElement) => {
                 const toBlob = (quality?: number) => {
+                  if (quality !== undefined && quality < 0.1) return
                   canvas.toBlob(
                     (blob) => {
                       if (!blob) return
                       if (blob.size < 4718592) onRender(blob)
-                      else toBlob(quality === undefined ? 1 : quality - 0.1)
+                      else toBlob(quality === undefined ? 1 : quality * 0.9)
                     },
                     quality === undefined ? 'image/png' : 'image/jpeg',
                     quality

--- a/src/components/Print/index.tsx
+++ b/src/components/Print/index.tsx
@@ -71,7 +71,13 @@ const Print = ({ image, onClose }: PrintProps) => {
             onClick={() => {
               setIsUploading(true)
               const formData = new FormData()
-              formData.append('file', new File([image], 'image.png'))
+              formData.append(
+                'file',
+                new File(
+                  [image],
+                  image.type === 'image/png' ? 'image.png' : 'image.jpg'
+                )
+              )
               formData.append('userAgent', navigator.userAgent)
               reservePrint(formData).then((response) => {
                 setResponse(response)


### PR DESCRIPTION
- 出力画像のサイズが大きいときに印刷リクエストに失敗する
- 大きすぎるときに、JPEGにしたり、品質を下げたりする処理の追加
- 印刷APIの制約が10MB、Vercelの制約が4.5MB
  - 現状、`4718592`を直打ちしているが、環境変数にするべきか悩んでるので相談したい