### PR TITLE
受け取り（予約含む）件数の取得

### DIFF
--- a/src/app/create/new/page.tsx
+++ b/src/app/create/new/page.tsx
@@ -2,10 +2,14 @@ import { getServerSession } from 'next-auth'
 import EditCard from '../../../layouts/EditCard'
 import { authOptions } from '../../api/auth/[...nextauth]/authOptions'
 import { redirect } from 'next/navigation'
+import { countReceivedRecords } from '../../../utils/strapi/receivedCard'
 
 const Page = async () => {
   const session = await getServerSession(authOptions)
   if (!session) redirect('/')
+
+  const receivedRecordsCount = await countReceivedRecords()
+  console.log(receivedRecordsCount)
 
   return <EditCard />
 }

--- a/src/utils/strapi/receivedCard.ts
+++ b/src/utils/strapi/receivedCard.ts
@@ -8,7 +8,6 @@ import {
   StrapiRecord,
 } from '.'
 import { getSharedCard } from './card/server'
-import { UserAttributes } from './user'
 import { authOptions } from '../../app/api/auth/[...nextauth]/authOptions'
 import { stringify } from 'qs'
 import { CardAttributes, checkIsDelivered } from './card'
@@ -18,9 +17,8 @@ export type ReceivedCardAttributes = {
   updatedAt: string
   publishedAt: string | null
   card: {
-    data: StrapiRecord<CardAttributes> | null
+    data: StrapiRecord<Omit<CardAttributes, 'creator'>> | null
   }
-  receiver: { data: StrapiRecord<UserAttributes> | null }
   randomSeed: number
 }
 
@@ -45,7 +43,6 @@ const recordFilter = (record: StrapiRecord<ReceivedCardAttributes>) => ({
           }
         : null,
     },
-    receiver: record.attributes.receiver,
     randomSeed: record.attributes.randomSeed,
   },
 })
@@ -62,7 +59,7 @@ export const getReceivedCard = async (id: number) => {
       `${
         process.env.NEXT_PUBLIC_STRAPI_BACKEND_URL
       }/api/received-cards/${id}?${stringify({
-        populate: ['card.userImages', 'receiver'],
+        populate: 'card.userImages',
         filters: {
           receiver: {
             id: {
@@ -105,7 +102,7 @@ export const getReceivedCards = async () => {
       `${
         process.env.NEXT_PUBLIC_STRAPI_BACKEND_URL
       }/api/received-cards?${stringify({
-        populate: ['card.userImages', 'receiver'],
+        populate: 'card.userImages',
         filters: {
           receiver: {
             id: {
@@ -154,7 +151,7 @@ export const getReceivedCardByCardId = async (cardId: number) => {
       `${
         process.env.NEXT_PUBLIC_STRAPI_BACKEND_URL
       }/api/received-cards?${stringify({
-        populate: ['card.userImages', 'receiver'],
+        populate: 'card.userImages',
         publicationState: 'preview',
         filters: {
           receiver: {


### PR DESCRIPTION
- 細かい仕様が決まってないので、一旦関数だけ
  - http://localhost:3000/create/new を開くと、サーバーのconsoleに数字を出力する
- 作業中に、filterするだけならpopulateする必要がなかったことに気づいたので、既存の型含めて整理してます