### PR TITLE
未受け取りの年賀状の詳細を見えるのを直す

### DIFF
--- a/src/app/receive/detail/[id]/page.tsx
+++ b/src/app/receive/detail/[id]/page.tsx
@@ -1,10 +1,15 @@
-import { redirect } from 'next/navigation'
+import { notFound } from 'next/navigation'
 import { getReceivedCard } from '../../../../utils/strapi/receivedCard'
 import ReceivedDetail from '../../../../layouts/ReceivedDetail'
 
 const Page = async ({ params }: { params: { id: string } }) => {
   const card = await getReceivedCard(parseInt(params.id, 10))
-  if (!card?.data.attributes.card.data) redirect('/receive/list')
+  if (
+    !card?.data.attributes.card.data ||
+    card.data.attributes.publishedAt === null
+  ) {
+    notFound()
+  }
 
   return (
     <ReceivedDetail


### PR DESCRIPTION
`/receive/detail/[id]` でまだポストに入ってる年賀状の中身が見えちゃってたので直す