### PR TITLE
スクロールの無効化

### DIFF
--- a/src/app/layout.css.ts
+++ b/src/app/layout.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css'
+import * as disabledScrollStyle from '../components/DisableScroll/index.css'
 
 export const container = style({
   display: 'flex',
@@ -42,4 +43,10 @@ export const content = style({
   overflowY: 'auto',
   backgroundColor: '#f5f5f5',
   contain: 'paint',
+
+  selectors: {
+    [`&:has(${disabledScrollStyle.fixedScreen})`]: {
+      overflowY: 'hidden',
+    },
+  },
 })

--- a/src/components/DisableScroll/index.css.ts
+++ b/src/components/DisableScroll/index.css.ts
@@ -1,0 +1,7 @@
+import { style } from '@vanilla-extract/css'
+
+export const fixedScreen = style({
+  width: '100%',
+  height: '100%',
+  overflow: 'hidden',
+})

--- a/src/components/DisableScroll/index.tsx
+++ b/src/components/DisableScroll/index.tsx
@@ -1,0 +1,11 @@
+import * as styles from './index.css'
+
+type DisableScrollProps = {
+  children: React.ReactNode
+}
+
+const DisableSctoll = ({ children }: DisableScrollProps) => {
+  return <div className={styles.fixedScreen}>{children}</div>
+}
+
+export default DisableSctoll

--- a/src/layouts/EditCard/index.tsx
+++ b/src/layouts/EditCard/index.tsx
@@ -6,6 +6,7 @@ import * as styles from './index.css'
 import Meta from './Meta'
 import Edit from './Edit'
 import { useEditCard } from './EditCardProvider'
+import FixedPage from '../../components/DisableScroll'
 
 const EditCard = () => {
   const {
@@ -17,40 +18,42 @@ const EditCard = () => {
   const [isLoading, setIsLoading] = useState(false)
 
   return (
-    <div
-      className={styles.screen}
-      style={
-        isLoading
-          ? {
-              pointerEvents: isLoading ? 'none' : 'auto',
-              filter: isLoading ? 'brightness(0.5)' : 'none',
-            }
-          : {}
-      }
-    >
-      <Meta />
-      <div className={styles.cardWrapper}>
-        <Card
-          layout={cardLayout}
-          background={cardBackground}
-          userImages={userImages}
-          edit={{
+    <FixedPage>
+      <div
+        className={styles.screen}
+        style={
+          isLoading
+            ? {
+                pointerEvents: isLoading ? 'none' : 'auto',
+                filter: isLoading ? 'brightness(0.5)' : 'none',
+              }
+            : {}
+        }
+      >
+        <Meta />
+        <div className={styles.cardWrapper}>
+          <Card
+            layout={cardLayout}
+            background={cardBackground}
+            userImages={userImages}
+            edit={{
+              isAnyFocused,
+              setIsAnyFocused,
+              setLayout: setCardLayout,
+              setBackground: setCardBackground,
+              setUserImages,
+            }}
+          />
+        </div>
+        <Edit
+          {...{
             isAnyFocused,
             setIsAnyFocused,
-            setLayout: setCardLayout,
-            setBackground: setCardBackground,
-            setUserImages,
+            setIsLoading,
           }}
         />
       </div>
-      <Edit
-        {...{
-          isAnyFocused,
-          setIsAnyFocused,
-          setIsLoading,
-        }}
-      />
-    </div>
+    </FixedPage>
   )
 }
 


### PR DESCRIPTION
- テキスト編集後など、iOS Safariで編集画面のドラッグで画面がスクロールされてしまうことがあったので、対策する