### PR TITLE
予約済み年賀状の受け取りアニメーション

### DIFF
--- a/src/layouts/Shared/index.tsx
+++ b/src/layouts/Shared/index.tsx
@@ -178,7 +178,8 @@ const Shared = ({
                   <div
                     className={
                       styles.cardContainer[
-                        existingReceivedCard
+                        existingReceivedCard &&
+                        existingReceivedCard.attributes.publishedAt !== null
                           ? 'alreadyReceived'
                           : isReceived
                           ? 'received'
@@ -194,7 +195,12 @@ const Shared = ({
                       )}
                       randomVariants="revealing"
                       randomSeed={randomSeed}
-                      revealDelay={existingReceivedCard ? undefined : 1.5}
+                      revealDelay={
+                        existingReceivedCard &&
+                        existingReceivedCard.attributes.publishedAt !== null
+                          ? undefined
+                          : 1.5
+                      }
                     />
                     <Image
                       src={emptyCard}


### PR DESCRIPTION
予約済みかつ未受け取りの年賀状を受け取ろうとすると、背景などの装飾は受け取り前なのに、年賀状だけめくれていて受け取れない不具合の修正