### PR TITLE
リンクページのOG画像サイズ修正

### DIFF
--- a/src/app/link/[id]/page.tsx
+++ b/src/app/link/[id]/page.tsx
@@ -20,6 +20,9 @@ export const generateMetadata = async ({
     openGraph: {
       images: [`/api/og?shareId=${params.id}`],
     },
+    twitter: {
+      card: 'summary_large_image',
+    },
     robots: {
       index: false,
     },


### PR DESCRIPTION
リンクページ以外のOGP設定時に巻き込まれて小さくなってしまっていたので直す