### PR TITLE
CMSの画像サイズ選択ロジック修正

### DIFF
--- a/src/layouts/List/Created/index.tsx
+++ b/src/layouts/List/Created/index.tsx
@@ -52,7 +52,7 @@ const Created = ({ initialCards }: CreatedProps) => {
                     userImages={mediaRecordsToUrlSet(
                       card.attributes.userImages.data
                     )}
-                    maxFormat="small"
+                    maxFormat="thumbnail"
                   />
                 </div>
                 {card.attributes.publishedAt === null ? (

--- a/src/layouts/List/Received/index.tsx
+++ b/src/layouts/List/Received/index.tsx
@@ -52,7 +52,7 @@ const Received = ({ initialReceivedCards }: ReceivedProps) => {
                         receivedCard.attributes.card.data.attributes.userImages
                           .data
                       )}
-                      maxFormat="small"
+                      maxFormat="thumbnail"
                       randomVariants="revealed"
                       randomSeed={receivedCard.attributes.randomSeed}
                     />

--- a/src/utils/strapi/strapiImage.ts
+++ b/src/utils/strapi/strapiImage.ts
@@ -30,7 +30,7 @@ export const getImageUrl = (
   urlSet: ImageUrlSet,
   maxFormat: ImageFormat = 'original'
 ) => {
-  const maxFormatOfImage = urlSet.formats?.large
+  const availableMaxFormat = urlSet.formats?.large
     ? 'large'
     : urlSet.formats?.medium
     ? 'medium'
@@ -40,7 +40,7 @@ export const getImageUrl = (
     ? 'thumbnail'
     : 'original'
   const format =
-    imageFormats.indexOf(maxFormatOfImage) < imageFormats.indexOf(maxFormat)
+    imageFormats.indexOf(availableMaxFormat) < imageFormats.indexOf(maxFormat)
       ? 'original'
       : maxFormat
   const url =

--- a/src/utils/strapi/strapiImage.ts
+++ b/src/utils/strapi/strapiImage.ts
@@ -26,7 +26,10 @@ const imageFormats = [
 
 export type ImageFormat = (typeof imageFormats)[number]
 
-export const getImageUrl = (urlSet: ImageUrlSet, maxFormat?: ImageFormat) => {
+export const getImageUrl = (
+  urlSet: ImageUrlSet,
+  maxFormat: ImageFormat = 'original'
+) => {
   const maxFormatOfImage = urlSet.formats?.large
     ? 'large'
     : urlSet.formats?.medium
@@ -36,14 +39,14 @@ export const getImageUrl = (urlSet: ImageUrlSet, maxFormat?: ImageFormat) => {
     : urlSet.formats?.thumbnail
     ? 'thumbnail'
     : 'original'
-  const formatIndex = Math.max(
-    imageFormats.indexOf(maxFormat ?? 'original'),
-    imageFormats.indexOf(maxFormatOfImage)
-  )
+  const format =
+    imageFormats.indexOf(maxFormatOfImage) < imageFormats.indexOf(maxFormat)
+      ? 'original'
+      : maxFormat
   const url =
-    imageFormats[formatIndex] === 'original'
+    format === 'original'
       ? urlSet.url
-      : urlSet.formats?.[imageFormats[formatIndex]]?.url ?? urlSet.url
+      : urlSet.formats?.[format]?.url ?? urlSet.url
   return url.startsWith('/')
     ? `${process.env.NEXT_PUBLIC_STRAPI_BACKEND_URL}${url}`
     : url


### PR DESCRIPTION
`getImageUrl()`で、`maxFormat`が`urlSet`に含まれていない場合の挙動を変更

`maxFormat`が`urlSet`に含まれていない場合
変更前: `urlSet.formats`内で最大の画像のURLを返す。なければ`urlSet.url`(`original`)を返す
変更後: `urlSet.url`(`original`)を返す

例
`thumbnail`サイズまでしかない`urlSet`に対して、`maxFormat`を`medium`とした場合
変更前: `urlSet.thumbnail.url`を返す
変更後: `urlSet.url`を返す

変更の理由
`maxFormat`により近い画像サイズのURLを返せるようになるため