### PR TITLE
ログインボタンを押した時の挙動を整理する

### DIFF
--- a/src/app/create/detail/[id]/page.tsx
+++ b/src/app/create/detail/[id]/page.tsx
@@ -1,16 +1,22 @@
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 import Detail from '../../../../layouts/Detail'
 import DraftDetail from '../../../../layouts/DraftDetail'
 import { getCreatedCard } from '../../../../utils/strapi/card'
 import { Metadata } from 'next'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../../../api/auth/[...nextauth]/authOptions'
 
 export const metadata: Metadata = {
   title: '年賀状の詳細 - あけおめリンク',
 }
 
 const Page = async ({ params }: { params: { id: number } }) => {
-  const cardResponse = await getCreatedCard(params.id)
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    redirect('/')
+  }
 
+  const cardResponse = await getCreatedCard(params.id)
   if (!cardResponse) {
     notFound()
   }

--- a/src/app/create/edit/[id]/layout.tsx
+++ b/src/app/create/edit/[id]/layout.tsx
@@ -19,11 +19,7 @@ const Layout = async ({
 }>) => {
   const session = await getServerSession(authOptions)
   if (!session) {
-    redirect(
-      `/api/auth/signin?callbackUrl=${encodeURIComponent(
-        `/create/edit/${params.id}`
-      )}`
-    )
+    redirect('/')
   }
   return <EditCardProvider existingId={params.id}>{children}</EditCardProvider>
 }

--- a/src/app/create/new/[id]/page.tsx
+++ b/src/app/create/new/[id]/page.tsx
@@ -6,12 +6,9 @@ import { mediaRecordsToUrlSet } from '../../../../utils/strapi/strapiImage'
 
 const Page = async ({ params }: { params: { id: number } }) => {
   const session = await getServerSession(authOptions)
-  if (!session)
-    redirect(
-      `/api/auth/signin?callbackUrl=${encodeURIComponent(
-        `/create/new/${params.id}`
-      )}`
-    )
+  if (!session) {
+    redirect('/')
+  }
 
   const existingCard = await getCreatedCard(params.id)
   if (!existingCard) {

--- a/src/app/create/new/page.tsx
+++ b/src/app/create/new/page.tsx
@@ -5,10 +5,9 @@ import { addCard } from '../../../utils/strapi/card'
 
 const Page = async () => {
   const session = await getServerSession(authOptions)
-  if (!session)
-    redirect(
-      `/api/auth/signin?callbackUrl=${encodeURIComponent('/create/new')}`
-    )
+  if (!session) {
+    redirect('/')
+  }
 
   const newCard = await addCard({
     isDraft: true,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import ClientSessionProvider from './ClientSessionProvider'
 import StrapiAdapter from '../utils/db/StrapiAdapter'
 import AchievementPopup from '../layouts/AchievementPopup'
 import { GoogleAnalytics } from '@next/third-parties/google'
+import LoginDialogProvider from '../components/LoginButton/LoginDialogProvider'
 
 export const metadata: Metadata = {
   title: 'あけおめリンク',
@@ -38,8 +39,10 @@ const Layout = async ({
           <StickerProvider stickers={await getStickers()}>
             <div className={styles.display}>
               <div className={styles.inner}>
-                <div className={styles.content}>{children}</div>
-                <AchievementPopup />
+                <LoginDialogProvider>
+                  <div className={styles.content}>{children}</div>
+                  <AchievementPopup />
+                </LoginDialogProvider>
               </div>
             </div>
           </StickerProvider>

--- a/src/app/share/[id]/page.tsx
+++ b/src/app/share/[id]/page.tsx
@@ -1,15 +1,21 @@
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 import Share from '../../../layouts/Share'
 import { getCreatedCard } from '../../../utils/strapi/card'
 import { Metadata } from 'next'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../../api/auth/[...nextauth]/authOptions'
 
 export const metadata: Metadata = {
   title: '年賀状の共有 - あけおめリンク',
 }
 
 const Page = async ({ params }: { params: { id: number } }) => {
-  const cardResponse = await getCreatedCard(params.id)
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    redirect('/')
+  }
 
+  const cardResponse = await getCreatedCard(params.id)
   if (!cardResponse) {
     notFound()
   }

--- a/src/components/LoginButton/Dialog/index.css.ts
+++ b/src/components/LoginButton/Dialog/index.css.ts
@@ -1,0 +1,41 @@
+import { style } from '@vanilla-extract/css'
+import { color } from '../../../utils/styleSchema'
+
+export const screen = style({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+  backdropFilter: 'brightness(0.5)',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  padding: 16,
+})
+
+export const container = style({
+  width: '100%',
+  backgroundColor: color.gray[90],
+  borderRadius: 12,
+  padding: 30,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 24,
+  alignItems: 'center',
+})
+
+export const button = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  padding: '10px 24px',
+  textDecoration: 'none',
+  backgroundColor: color.gray[100],
+  color: color.gray[5],
+  borderRadius: 12,
+  fontWeight: 'bold',
+  border: 'none',
+  fontSize: 16,
+  cursor: 'pointer',
+})

--- a/src/components/LoginButton/Dialog/index.tsx
+++ b/src/components/LoginButton/Dialog/index.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import * as styles from './index.css'
+
+type DialogProps = {
+  onClose: () => void
+}
+
+const Dialog = ({ onClose }: DialogProps) => {
+  return (
+    <div className={styles.screen}>
+      <div className={styles.container}>
+        <span>
+          アプリ内ブラウザではご利用いただけません。
+          <br />
+          SafariやChromeなどの外部ブラウザをご利用ください。
+        </span>
+        <button className={styles.button} onClick={onClose}>
+          閉じる
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default Dialog

--- a/src/components/LoginButton/LoginDialogProvider.tsx
+++ b/src/components/LoginButton/LoginDialogProvider.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { createContext, useContext, useState } from 'react'
+import Dialog from './Dialog'
+
+const loginDialogContext = createContext<
+  | {
+      open: () => void
+    }
+  | undefined
+>(undefined)
+
+export const useLoginDialog = () => {
+  const context = useContext(loginDialogContext)
+  if (context === undefined) {
+    throw new Error('useLoginDialog must be used within a LoginDialogProvider')
+  }
+  return context
+}
+
+type LoginDialogProviderProps = {
+  children: React.ReactNode
+}
+
+const LoginDialogProvider = ({ children }: LoginDialogProviderProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <loginDialogContext.Provider
+      value={{
+        open: () => setIsOpen(true),
+      }}
+    >
+      {children}
+      {isOpen && <Dialog onClose={() => setIsOpen(false)} />}
+    </loginDialogContext.Provider>
+  )
+}
+
+export default LoginDialogProvider

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -8,9 +8,14 @@ import { useLoginDialog } from './LoginDialogProvider'
 type LoginButtonProps = {
   className?: string
   children?: React.ReactNode
+  callbackUrl?: string
 }
 
-const LoginButton = ({ className, children }: LoginButtonProps) => {
+const LoginButton = ({
+  className,
+  children,
+  callbackUrl,
+}: LoginButtonProps) => {
   const userAgent = useSyncExternalStore(
     () => () => {},
     () => window.navigator.userAgent.toLowerCase().trim(),
@@ -72,7 +77,14 @@ const LoginButton = ({ className, children }: LoginButtonProps) => {
   }
 
   return (
-    <button className={className} onClick={() => signIn('google')}>
+    <button
+      className={className}
+      onClick={() =>
+        signIn('google', {
+          callbackUrl,
+        })
+      }
+    >
       {children}
     </button>
   )

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { signIn } from 'next-auth/react'
+import Link from 'next/link'
+import { useState, useSyncExternalStore } from 'react'
+import { useLoginDialog } from './LoginDialogProvider'
+
+type LoginButtonProps = {
+  className?: string
+  children?: React.ReactNode
+}
+
+const LoginButton = ({ className, children }: LoginButtonProps) => {
+  const userAgent = useSyncExternalStore(
+    () => () => {},
+    () => window.navigator.userAgent.toLowerCase().trim(),
+    () => undefined
+  )
+
+  const browser = (() => {
+    if (!userAgent) return
+
+    const isFacebook =
+      userAgent.includes('fbios') || userAgent.includes('fb_iab')
+    const isInstagram = userAgent.includes('instagram')
+    const isLine = userAgent.includes('line/')
+    const isWebview = userAgent.includes('webview') // e.g. Rakuten Link
+    return isFacebook
+      ? 'facebook'
+      : isInstagram
+      ? 'instagram'
+      : isLine
+      ? 'line'
+      : isWebview
+      ? 'webview'
+      : 'other'
+  })()
+
+  const os = (() => {
+    if (!userAgent) return
+
+    const isAndroid = userAgent.includes('android')
+    const isIos =
+      userAgent.includes('iphone') ||
+      userAgent.includes('ipod') ||
+      userAgent.includes('ipad')
+    return isAndroid ? 'android' : isIos ? 'ios' : 'other'
+  })()
+
+  const { open: openLoginDialog } = useLoginDialog()
+
+  const [isFirstClick, setIsFirstClick] = useState(true)
+
+  if (browser && browser !== 'other') {
+    return (
+      <Link
+        href={`intent://${String(window.location).replace(
+          /^.+:\/\//,
+          ''
+        )}#Intent;scheme=https;end;`}
+        className={className}
+        onClick={() => {
+          setIsFirstClick(false)
+          if (os === 'android' && isFirstClick) return
+
+          openLoginDialog()
+        }}
+      >
+        {children}
+      </Link>
+    )
+  }
+
+  return (
+    <button className={className} onClick={() => signIn('google')}>
+      {children}
+    </button>
+  )
+}
+
+export default LoginButton

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -29,6 +29,7 @@ const LoginButton = ({
       userAgent.includes('fbios') || userAgent.includes('fb_iab')
     const isInstagram = userAgent.includes('instagram')
     const isLine = userAgent.includes('line/')
+    const isYahoo = userAgent.includes('yjapp')
     const isWebview = userAgent.includes('webview') // e.g. Rakuten Link
     return isFacebook
       ? 'facebook'
@@ -36,6 +37,8 @@ const LoginButton = ({
       ? 'instagram'
       : isLine
       ? 'line'
+      : isYahoo
+      ? 'yahoo'
       : isWebview
       ? 'webview'
       : 'other'

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -30,6 +30,7 @@ const LoginButton = ({
     const isInstagram = userAgent.includes('instagram')
     const isLine = userAgent.includes('line/')
     const isYahoo = userAgent.includes('yjapp')
+    const isTwitter = userAgent.includes('twitter')
     const isWebview = userAgent.includes('webview') // e.g. Rakuten Link
     return isFacebook
       ? 'facebook'
@@ -39,6 +40,8 @@ const LoginButton = ({
       ? 'line'
       : isYahoo
       ? 'yahoo'
+      : isTwitter
+      ? 'twitter'
       : isWebview
       ? 'webview'
       : 'other'

--- a/src/layouts/List/index.tsx
+++ b/src/layouts/List/index.tsx
@@ -13,9 +13,7 @@ const List = async ({ tab }: ListProps) => {
   if (tab === 'created') {
     const cards = await getCreatedCards()
     if (!cards) {
-      redirect(
-        `/api/auth/signin?callbackUrl=${encodeURIComponent('/create/list')}`
-      )
+      redirect('/')
     }
     return (
       <>
@@ -27,9 +25,7 @@ const List = async ({ tab }: ListProps) => {
   if (tab === 'received') {
     const receivedCards = await getReceivedCards()
     if (!receivedCards) {
-      redirect(
-        `/api/auth/signin?callbackUrl=${encodeURIComponent('/receive/list')}`
-      )
+      redirect('/')
     }
     return (
       <>

--- a/src/layouts/Post/index.tsx
+++ b/src/layouts/Post/index.tsx
@@ -13,9 +13,7 @@ const Post = async ({ tab }: PostProps) => {
   if (tab === 'delivered') {
     const receivedCards = await getReservedCards({ filter: 'delivered' })
     if (!receivedCards) {
-      redirect(
-        `/api/auth/signin?callbackUrl=${encodeURIComponent('/post/delivered')}`
-      )
+      redirect('/')
     }
     return (
       <div className={styles.container}>
@@ -29,11 +27,7 @@ const Post = async ({ tab }: PostProps) => {
   if (tab === 'undelivered') {
     const receivedCards = await getReservedCards({ filter: 'undelivered' })
     if (!receivedCards) {
-      redirect(
-        `/api/auth/signin?callbackUrl=${encodeURIComponent(
-          '/post/undelivered'
-        )}`
-      )
+      redirect('/')
     }
     return (
       <div className={styles.container}>

--- a/src/layouts/Shared/index.tsx
+++ b/src/layouts/Shared/index.tsx
@@ -256,9 +256,13 @@ const Shared = ({
                     <Link className={styles.primaryButton} href="/create/list">
                       つくった年賀状一覧へ
                     </Link>
-                  ) : (
+                  ) : strapiUserId !== undefined ? (
                     <Link className={styles.primaryButton} href="/receive/list">
                       もらった年賀状一覧へ
+                    </Link>
+                  ) : (
+                    <Link className={styles.primaryButton} href="/create/new">
+                      年賀状を作ってみる
                     </Link>
                   ))
                 ) : strapiUserId === cardCreatorId ? (

--- a/src/layouts/Shared/index.tsx
+++ b/src/layouts/Shared/index.tsx
@@ -14,7 +14,6 @@ import {
   ReceivedCardAttributes,
 } from '../../utils/strapi/receivedCard'
 import { getLocalReceivedCard, putLocalReceivedCard } from '../../utils/db'
-import { signIn } from 'next-auth/react'
 import { CardAttributes } from '../../utils/strapi/card'
 import Image from 'next/image'
 import emptyCard from './empty-card.svg'

--- a/src/layouts/Shared/index.tsx
+++ b/src/layouts/Shared/index.tsx
@@ -28,6 +28,7 @@ import matsu from './matsu.svg'
 import { color } from '../../utils/styleSchema'
 import cart from './cart.svg'
 import pin from './pin.svg'
+import LoginButton from '../../components/LoginButton'
 
 type SharedProps = {
   cardCreatorId: number
@@ -109,11 +110,7 @@ const Shared = ({
     }
   }
 
-  const reserve = async () => {
-    if (!strapiUserId) {
-      signIn()
-      return
-    }
+  const reserve = async (strapiUserId: number) => {
     if (strapiUserId === cardCreatorId) return
     if (isReserved) return
 
@@ -261,9 +258,12 @@ const Shared = ({
                       もらった年賀状一覧へ
                     </Link>
                   ) : (
-                    <Link className={styles.primaryButton} href="/create/new">
+                    <LoginButton
+                      className={styles.primaryButton}
+                      callbackUrl="/create/new"
+                    >
                       年賀状を作ってみる
-                    </Link>
+                    </LoginButton>
                   ))
                 ) : strapiUserId === cardCreatorId ? (
                   <Link className={styles.primaryButton} href="/create/list">
@@ -273,10 +273,17 @@ const Shared = ({
                   <Link className={styles.primaryButton} href="/create/new">
                     年賀状を作ってみる
                   </Link>
-                ) : (
-                  <button className={styles.primaryButton} onClick={reserve}>
+                ) : strapiUserId !== undefined ? (
+                  <button
+                    className={styles.primaryButton}
+                    onClick={() => reserve(strapiUserId)}
+                  >
                     受け取り予約する
                   </button>
+                ) : (
+                  <LoginButton className={styles.primaryButton}>
+                    受け取り予約する
+                  </LoginButton>
                 )}
                 {isDelivered && isReceived && (
                   <>

--- a/src/layouts/Top/index.css.ts
+++ b/src/layouts/Top/index.css.ts
@@ -12,9 +12,9 @@ export const container = style({
 })
 
 export const content = style({
-  paddingTop: '140px'
+  paddingTop: '140px',
 })
-  
+
 export const discription = style({
   paddingTop: '12px',
   paddingBottom: '192px',
@@ -25,18 +25,18 @@ export const discription = style({
 export const redText = style({
   color: color.red[5],
 })
-  
+
 export const image = style({
   marginBottom: '114px',
   maxWidth: '100%',
   height: 'auto',
 })
-  
+
 export const loginButton = style({
-	display: 'flex',
+  display: 'flex',
   justifyContent: 'center',
 })
-  
+
 export const buttonLayout = style({
   padding: '14px 24px',
   fontSize: '16px',
@@ -45,12 +45,13 @@ export const buttonLayout = style({
   border: 'none',
   borderRadius: '12px',
   cursor: 'pointer',
-	width: '280px',
-	height: '50px'
+  width: '280px',
+  height: '50px',
+  textDecoration: 'none',
 })
 
 export const linkText = style({
-  paddingTop: '11px'
+  paddingTop: '11px',
 })
 
 export const privacy = style({
@@ -58,7 +59,7 @@ export const privacy = style({
   fontWeight: 'bold',
   color: color.red[5],
   textDecoration: 'none',
-  paddingRight: '12px'
+  paddingRight: '12px',
 })
 
 export const terms = style({

--- a/src/layouts/Top/index.tsx
+++ b/src/layouts/Top/index.tsx
@@ -1,25 +1,32 @@
-'use client'
-
 import * as styles from './index.css'
 import Image from 'next/image'
-import { signIn } from 'next-auth/react'
 import Link from 'next/link'
 import akeomeLinkLogo from '../../assets/akeome-link-logo.svg'
+import LoginButton from '../../components/LoginButton'
 
 const Top = () => {
   return (
     <div className={styles.container}>
       <div className={styles.content}>
-        <Image src={akeomeLinkLogo} width={255} alt='akeomeLinkLogo' priority />
+        <Image src={akeomeLinkLogo} width={255} alt="akeomeLinkLogo" priority />
         <div className={styles.discription}>
-          <div><span className={styles.redText}>SNS</span>で<span className={styles.redText}>年賀状</span>を交換</div>
+          <div>
+            <span className={styles.redText}>SNS</span>で
+            <span className={styles.redText}>年賀状</span>を交換
+          </div>
         </div>
         <div className={styles.loginButton}>
-          <button className={styles.buttonLayout} onClick={() => signIn()}>Googleアカウントで開始する</button>
+          <LoginButton className={styles.buttonLayout}>
+            Googleアカウントで開始する
+          </LoginButton>
         </div>
         <div className={styles.linkText}>
-          <Link className={styles.privacy} href='/privacy'>プライバシーポリシー</Link>
-          <Link className={styles.terms} href='/terms'>利用規約</Link>
+          <Link className={styles.privacy} href="/privacy">
+            プライバシーポリシー
+          </Link>
+          <Link className={styles.terms} href="/terms">
+            利用規約
+          </Link>
         </div>
       </div>
     </div>

--- a/src/utils/strapi/card.ts
+++ b/src/utils/strapi/card.ts
@@ -48,7 +48,7 @@ export type DraftCardAttributes = {
 export const getCreatedCard = async (id: number) => {
   const session = await getServerSession(authOptions)
   if (!session) {
-    return undefined
+    throw new Error('Unauthorized')
   }
 
   try {


### PR DESCRIPTION
#97 でhotfix済み

- next-authのログインページを使わないようにする
  - 直接ログイン必須のページにアクセスした場合には、`/`に遷移する
  - ログインボタン、ログイン必須のボタンを押した場合には、直接Googleの画面を開く
- アプリ内ブラウザでログインしないようにする
  - LINEやInstagramなどのアプリ内ブラウザでログインすると `403: disallowed_useragent` になる
  - [ Googleのポリシー](https://developers.google.com/identity/protocols/oauth2/policies#browsers)によるもの
  - iOS(Android以外)ではダイアログを表示して、Googleの画面には遷移しない
  - Androidでは、`intent://`を使って、現在のページを外部のブラウザを開く
    - 確認ダイアログを一度閉じると再度開くことができなくなるため、2回目からはiOSと同様
  - アプリ内ブラウザかどうかの判定はUser-Agentで行っていて、確認済みアプリは以下
    - LINE
    - Instagram
    - Facebook
    - Rakuten Link(Androidのみ)
    - Yahoo! JAPAN
  - 以下のアプリについては、今後検証する必要がありそうだが、一旦メジャーケースを優先してこのPRはマージしたい
    - Rakuten Link(iOS)
    - ＋メッセージ