### PR TITLE
編集UI改善

### DIFF
--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -554,7 +554,7 @@ const Card = ({
                     className={styles.control.remove}
                     onClick={(event) => {
                       event.stopPropagation()
-                      edit?.setLayout(layout.slice(0, index))
+                      edit?.setLayout(layout.slice(0, -1))
                       edit?.setIsAnyFocused(false)
 
                       const content = layout[index].content

--- a/src/layouts/EditCard/Edit/index.css.ts
+++ b/src/layouts/EditCard/Edit/index.css.ts
@@ -137,7 +137,7 @@ export const navButtonIcon = style({
   fontSize: 24,
 })
 
-export const textEditWindow = style({
+const textEditWindowBase = style({
   position: 'absolute',
   top: 0,
   left: 0,
@@ -150,6 +150,17 @@ export const textEditWindow = style({
   gap: 16,
   padding: 16,
   backgroundColor: `rgb(255 255 255 / 0.9)`,
+})
+
+export const textEditWindow = styleVariants({
+  active: [textEditWindowBase],
+  hidden: [
+    textEditWindowBase,
+    {
+      opacity: 0,
+      pointerEvents: 'none',
+    },
+  ],
 })
 
 export const textEditButtonContainer = style({

--- a/src/layouts/EditCard/Edit/index.css.ts
+++ b/src/layouts/EditCard/Edit/index.css.ts
@@ -107,6 +107,7 @@ const navButtonBase = style({
   borderTop: `2px solid`,
   fontWeight: 'bold',
   cursor: 'pointer',
+  color: color.gray[5],
 })
 
 export const navButton = styleVariants({
@@ -121,14 +122,12 @@ export const navButton = styleVariants({
   default: [
     navButtonBase,
     {
-      color: color.gray[5],
       borderColor: 'transparent',
     },
   ],
   active: [
     navButtonBase,
     {
-      color: color.red[5],
       borderColor: color.red[5],
     },
   ],

--- a/src/layouts/EditCard/Edit/index.css.ts
+++ b/src/layouts/EditCard/Edit/index.css.ts
@@ -27,7 +27,7 @@ export const controlGrid = style({
   paddingBlock: 8,
 })
 
-export const controlButton = style({
+const controlButtonBase = style({
   height: '100%',
   display: 'flex',
   justifyContent: 'center',
@@ -42,6 +42,17 @@ export const controlButton = style({
   borderRadius: 6,
   cursor: 'pointer',
   position: 'relative',
+})
+
+export const controlButton = styleVariants({
+  default: [controlButtonBase],
+  disabled: [
+    controlButtonBase,
+    {
+      opacity: 0.5,
+      pointerEvents: 'none',
+    },
+  ],
 })
 
 export const controlInput = style({

--- a/src/layouts/EditCard/Edit/index.css.ts
+++ b/src/layouts/EditCard/Edit/index.css.ts
@@ -107,7 +107,6 @@ const navButtonBase = style({
   borderTop: `2px solid`,
   fontWeight: 'bold',
   cursor: 'pointer',
-  color: color.gray[5],
 })
 
 export const navButton = styleVariants({
@@ -117,18 +116,21 @@ export const navButton = styleVariants({
       opacity: 0.5,
       pointerEvents: 'none',
       borderColor: 'transparent',
+      color: color.gray[5],
     },
   ],
   default: [
     navButtonBase,
     {
       borderColor: 'transparent',
+      color: color.gray[5],
     },
   ],
   active: [
     navButtonBase,
     {
       borderColor: color.red[5],
+      color: color.red[5],
     },
   ],
 })

--- a/src/layouts/EditCard/Edit/index.tsx
+++ b/src/layouts/EditCard/Edit/index.tsx
@@ -413,6 +413,10 @@ const Edit = ({ isAnyFocused, setIsAnyFocused, setIsLoading }: EditProps) => {
               className={styles.textEditButton}
               onClick={() => {
                 setIsTextEditing(false)
+                if (focusedContent.text === '') {
+                  setCardLayout(cardLayout.slice(0, -1))
+                  setIsAnyFocused(false)
+                }
               }}
             >
               完了

--- a/src/layouts/EditCard/Edit/index.tsx
+++ b/src/layouts/EditCard/Edit/index.tsx
@@ -107,7 +107,7 @@ const Edit = ({ isAnyFocused, setIsAnyFocused, setIsLoading }: EditProps) => {
         {activeTab == 'background' ? (
           <div className={styles.control}>
             <div className={styles.controlGrid}>
-              <label className={styles.controlButton}>
+              <label className={styles.controlButton.default}>
                 <FaImage size={20} />
                 写真を選択
                 <input
@@ -136,7 +136,7 @@ const Edit = ({ isAnyFocused, setIsAnyFocused, setIsLoading }: EditProps) => {
                   }}
                 />
               </label>
-              <label className={styles.controlButton}>
+              <label className={styles.controlButton.default}>
                 <FaPalette size={20} />
                 カラー
                 <input
@@ -162,7 +162,7 @@ const Edit = ({ isAnyFocused, setIsAnyFocused, setIsLoading }: EditProps) => {
         ) : activeTab == 'userImage' ? (
           <div className={styles.control}>
             <div className={styles.controlGrid}>
-              <label className={styles.controlButton}>
+              <label className={styles.controlButton.default}>
                 <FaPlus size={20} />
                 追加
                 <input
@@ -236,7 +236,7 @@ const Edit = ({ isAnyFocused, setIsAnyFocused, setIsLoading }: EditProps) => {
           <div className={styles.control}>
             <div className={styles.controlGrid}>
               <button
-                className={styles.controlButton}
+                className={styles.controlButton.default}
                 onClick={() => {
                   setCardLayout([
                     ...cardLayout,
@@ -256,75 +256,100 @@ const Edit = ({ isAnyFocused, setIsAnyFocused, setIsLoading }: EditProps) => {
                 <FaPlus size={20} />
                 追加
               </button>
-              {focusedContent?.type === 'text' && (
-                <>
-                  <button
-                    className={styles.controlButton}
-                    onClick={() => {
-                      setIsTextEditing(true)
-                    }}
-                  >
-                    <FaPen size={20} />
-                    編集
-                  </button>
-                  <label className={styles.controlButton}>
-                    <FaPalette size={20} />
-                    カラー
-                    <input
-                      className={styles.controlInput}
-                      type="color"
-                      value={focusedContent.color}
-                      onChange={(event) => {
-                        setCardLayout(
-                          cardLayout.slice(0, -1).concat({
-                            ...cardLayout[cardLayout.length - 1],
-                            content: {
-                              ...focusedContent,
-                              color: event.target.value,
-                            },
-                          })
-                        )
-                      }}
-                    />
-                  </label>
-                  <button
-                    className={styles.controlButton}
-                    onClick={() => {
-                      setCardLayout(
-                        cardLayout.slice(0, -1).concat({
-                          ...cardLayout[cardLayout.length - 1],
-                          content: {
-                            ...focusedContent,
-                            align:
-                              focusedContent.align == 'left'
-                                ? 'center'
-                                : focusedContent.align == 'center'
-                                ? 'right'
-                                : 'left',
-                          },
-                        })
-                      )
-                    }}
-                  >
-                    {focusedContent.align == 'left' ? (
-                      <>
-                        <FaAlignLeft size={20} />
-                        左揃え
-                      </>
-                    ) : focusedContent.align == 'center' ? (
-                      <>
-                        <FaAlignCenter size={20} />
-                        中央揃え
-                      </>
-                    ) : (
-                      <>
-                        <FaAlignRight size={20} />
-                        右揃え
-                      </>
-                    )}
-                  </button>
-                </>
-              )}
+              <button
+                className={
+                  styles.controlButton[
+                    focusedContent?.type === 'text' ? 'default' : 'disabled'
+                  ]
+                }
+                onClick={() => {
+                  if (focusedContent?.type !== 'text') return
+                  setIsTextEditing(true)
+                }}
+              >
+                <FaPen size={20} />
+                編集
+              </button>
+              <label
+                className={
+                  styles.controlButton[
+                    focusedContent?.type === 'text' ? 'default' : 'disabled'
+                  ]
+                }
+              >
+                <FaPalette size={20} />
+                カラー
+                <input
+                  className={styles.controlInput}
+                  type="color"
+                  value={
+                    focusedContent?.type === 'text'
+                      ? focusedContent.color
+                      : '#000'
+                  }
+                  onChange={(event) => {
+                    if (focusedContent?.type !== 'text') return
+                    setCardLayout(
+                      cardLayout.slice(0, -1).concat({
+                        ...cardLayout[cardLayout.length - 1],
+                        content: {
+                          ...focusedContent,
+                          color: event.target.value,
+                        },
+                      })
+                    )
+                  }}
+                />
+              </label>
+              <button
+                className={
+                  styles.controlButton[
+                    focusedContent?.type === 'text' ? 'default' : 'disabled'
+                  ]
+                }
+                onClick={() => {
+                  if (focusedContent?.type !== 'text') return
+                  setCardLayout(
+                    cardLayout.slice(0, -1).concat({
+                      ...cardLayout[cardLayout.length - 1],
+                      content: {
+                        ...focusedContent,
+                        align:
+                          focusedContent.align == 'left'
+                            ? 'center'
+                            : focusedContent.align == 'center'
+                            ? 'right'
+                            : 'left',
+                      },
+                    })
+                  )
+                }}
+              >
+                {focusedContent?.type === 'text' ? (
+                  focusedContent.align == 'left' ? (
+                    <>
+                      <FaAlignLeft size={20} />
+                      左揃え
+                    </>
+                  ) : focusedContent.align == 'center' ? (
+                    <>
+                      <FaAlignCenter size={20} />
+                      中央揃え
+                    </>
+                  ) : (
+                    <>
+                      <FaAlignRight size={20} />
+                      右揃え
+                    </>
+                  )
+                ) : (
+                  <>
+                    <FaAlignCenter size={20} />
+                    中央揃え
+                  </>
+                )}
+              </button>
+              {focusedContent?.type === 'text' && <></>}
             </div>
           </div>
         )}

--- a/src/layouts/EditCard/Edit/index.tsx
+++ b/src/layouts/EditCard/Edit/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { UserImages } from '../../../components/Card'
 import * as styles from './index.css'
 import { useStickers } from '../../../app/StickerProvider'
@@ -86,6 +86,8 @@ const Edit = ({ isAnyFocused, setIsAnyFocused, setIsLoading }: EditProps) => {
       })
     event.target.value = ''
   }
+
+  const textEditTextareaRef = useRef<HTMLTextAreaElement | null>(null)
 
   if (!cardLayout || !cardBackground || !userImages) {
     return (
@@ -265,6 +267,13 @@ const Edit = ({ isAnyFocused, setIsAnyFocused, setIsLoading }: EditProps) => {
                 onClick={() => {
                   if (focusedContent?.type !== 'text') return
                   setIsTextEditing(true)
+                  textEditTextareaRef.current?.focus()
+                  textEditTextareaRef.current?.setSelectionRange(
+                    focusedContent.text === 'テキストを入力'
+                      ? 0
+                      : focusedContent.text.length,
+                    focusedContent.text.length
+                  )
                 }}
               >
                 <FaPen size={20} />
@@ -406,43 +415,52 @@ const Edit = ({ isAnyFocused, setIsAnyFocused, setIsLoading }: EditProps) => {
           テキスト
         </button>
       </div>
-      {isTextEditing && focusedContent?.type === 'text' && (
-        <div className={styles.textEditWindow}>
-          <div className={styles.textEditButtonContainer}>
-            <button
-              className={styles.textEditButton}
-              onClick={() => {
-                setIsTextEditing(false)
-                if (focusedContent.text === '') {
-                  setCardLayout(cardLayout.slice(0, -1))
-                  setIsAnyFocused(false)
-                }
-              }}
-            >
-              完了
-            </button>
-          </div>
-          <div className={styles.textEditTextareaWrapper}>
-            {focusedContent.text}
-            {'\u200b'}
-            <textarea
-              className={styles.textEditTextarea}
-              value={focusedContent.text}
-              onChange={(event) => {
-                setCardLayout(
-                  cardLayout.slice(0, -1).concat({
-                    ...cardLayout[cardLayout.length - 1],
-                    content: {
-                      ...focusedContent,
-                      text: event.target.value,
-                    },
-                  })
-                )
-              }}
-            />
-          </div>
+      <div
+        className={
+          styles.textEditWindow[
+            isTextEditing && focusedContent?.type === 'text'
+              ? 'active'
+              : 'hidden'
+          ]
+        }
+      >
+        <div className={styles.textEditButtonContainer}>
+          <button
+            className={styles.textEditButton}
+            onClick={() => {
+              if (focusedContent?.type !== 'text') return
+              setIsTextEditing(false)
+              if (focusedContent.text === '') {
+                setCardLayout(cardLayout.slice(0, -1))
+                setIsAnyFocused(false)
+              }
+            }}
+          >
+            完了
+          </button>
         </div>
-      )}
+        <div className={styles.textEditTextareaWrapper}>
+          {focusedContent?.type === 'text' ? focusedContent.text : ''}
+          {'\u200b'}
+          <textarea
+            ref={textEditTextareaRef}
+            className={styles.textEditTextarea}
+            value={focusedContent?.type === 'text' ? focusedContent.text : ''}
+            onChange={(event) => {
+              if (focusedContent?.type !== 'text') return
+              setCardLayout(
+                cardLayout.slice(0, -1).concat({
+                  ...cardLayout[cardLayout.length - 1],
+                  content: {
+                    ...focusedContent,
+                    text: event.target.value,
+                  },
+                })
+              )
+            }}
+          />
+        </div>
+      </div>
       {error !== null && (
         <div className={styles.errorContainer}>
           <FaTriangleExclamation size={20} />

--- a/src/layouts/EditCard/Edit/index.tsx
+++ b/src/layouts/EditCard/Edit/index.tsx
@@ -89,6 +89,16 @@ const Edit = ({ isAnyFocused, setIsAnyFocused, setIsLoading }: EditProps) => {
 
   const textEditTextareaRef = useRef<HTMLTextAreaElement | null>(null)
 
+  const completeTextEditing = () => {
+    if (focusedContent?.type !== 'text') return
+    if (cardLayout === null) return
+    setIsTextEditing(false)
+    if (focusedContent.text === '') {
+      setCardLayout(cardLayout.slice(0, -1))
+      setIsAnyFocused(false)
+    }
+  }
+
   if (!cardLayout || !cardBackground || !userImages) {
     return (
       <>
@@ -427,14 +437,7 @@ const Edit = ({ isAnyFocused, setIsAnyFocused, setIsLoading }: EditProps) => {
         <div className={styles.textEditButtonContainer}>
           <button
             className={styles.textEditButton}
-            onClick={() => {
-              if (focusedContent?.type !== 'text') return
-              setIsTextEditing(false)
-              if (focusedContent.text === '') {
-                setCardLayout(cardLayout.slice(0, -1))
-                setIsAnyFocused(false)
-              }
-            }}
+            onClick={completeTextEditing}
           >
             完了
           </button>
@@ -458,6 +461,7 @@ const Edit = ({ isAnyFocused, setIsAnyFocused, setIsLoading }: EditProps) => {
                 })
               )
             }}
+            onBlur={completeTextEditing}
           />
         </div>
       </div>

--- a/src/layouts/EditCard/Setting/index.css.ts
+++ b/src/layouts/EditCard/Setting/index.css.ts
@@ -29,16 +29,31 @@ export const postNumberContainer = style({
   marginBottom: -8,
 })
 
+export const inputGroup = style({
+  display: 'flex',
+  gap: 16,
+  flexDirection: 'column',
+})
+
 export const inputContainer = style({
   display: 'flex',
   width: '100%',
   flexDirection: 'column',
-  gap: 8,
+  gap: 6,
+})
+
+export const inputNotice = style({
+  fontSize: 12,
+  color: color.gray[40],
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  fontWeight: 'bold',
 })
 
 export const titleGroup = style({
   display: 'flex',
-  gap: 8,
+  gap: 6,
   alignItems: 'flex-end',
   justifyContent: 'space-between',
 })

--- a/src/layouts/EditCard/Setting/index.css.ts
+++ b/src/layouts/EditCard/Setting/index.css.ts
@@ -80,6 +80,10 @@ const inputBase = style({
   ':disabled': {
     opacity: 0.5,
   },
+
+  '::placeholder': {
+    color: color.gray[40],
+  },
 })
 
 export const input = styleVariants({

--- a/src/layouts/EditCard/Setting/index.tsx
+++ b/src/layouts/EditCard/Setting/index.tsx
@@ -125,6 +125,7 @@ const Setting = () => {
                 value={title ?? ''}
                 onChange={(event) => setTitle(event.target.value)}
                 disabled={title === undefined}
+                placeholder="SNS用"
               />
               <div className={styles.inputNotice}>
                 <FaEyeSlash size={16} />

--- a/src/layouts/EditCard/Setting/index.tsx
+++ b/src/layouts/EditCard/Setting/index.tsx
@@ -2,7 +2,7 @@
 
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useSyncExternalStore } from 'react'
 import { extractPersonName } from '../../../utils/goolab'
 import * as styles from './index.css'
 import Meta from './Meta'
@@ -62,7 +62,22 @@ const Setting = () => {
 
   const now = new Date()
   const deliveredAt = calcDeliveredAt(now)
-  const isExpressAvailable = now.getMonth() === 0
+  const deliveredAtString = useSyncExternalStore(
+    () => () => {},
+    () =>
+      `${deliveredAt.getFullYear()}年${
+        deliveredAt.getMonth() + 1
+      }月${deliveredAt.getDate()}日 ${deliveredAt.getHours()}:${deliveredAt
+        .getMinutes()
+        .toString()
+        .padStart(2, '0')}`,
+    () => ''
+  )
+  const isExpressAvailable = useSyncExternalStore(
+    () => () => {},
+    () => now.getMonth() === 0,
+    () => undefined
+  )
 
   const save = () => {
     if (!title) return
@@ -153,15 +168,7 @@ const Setting = () => {
             <div className={styles.deliveredAtGroup}>
               <div className={styles.subTitle}>配達予定日</div>
               <div className={styles.deliveredAt}>
-                {isExpress ? (
-                  'いますぐ'
-                ) : (
-                  <>
-                    {deliveredAt.getFullYear()}年{deliveredAt.getMonth() + 1}月
-                    {deliveredAt.getDate()}日 {deliveredAt.getHours()}:
-                    {deliveredAt.getMinutes().toString().padStart(2, '0')}
-                  </>
-                )}
+                {isExpress ? 'いますぐ' : deliveredAtString}
               </div>
             </div>
           </div>

--- a/src/layouts/EditCard/Setting/index.tsx
+++ b/src/layouts/EditCard/Setting/index.tsx
@@ -2,7 +2,7 @@
 
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState, useSyncExternalStore } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import { extractPersonName } from '../../../utils/goolab'
 import * as styles from './index.css'
 import Meta from './Meta'
@@ -95,6 +95,8 @@ const Setting = () => {
     )
   }
 
+  const titleInputRef = useRef<HTMLInputElement>(null)
+
   return (
     <div className={styles.screen}>
       <Meta
@@ -117,6 +119,7 @@ const Setting = () => {
                 </div>
               </div>
               <input
+                ref={titleInputRef}
                 className={
                   styles.input[
                     title === undefined || title ? 'default' : 'error'
@@ -126,6 +129,11 @@ const Setting = () => {
                 onChange={(event) => setTitle(event.target.value)}
                 disabled={title === undefined}
                 placeholder="SNS用"
+                onClick={() => {
+                  if (title === '無題') {
+                    titleInputRef.current?.select()
+                  }
+                }}
               />
               <div className={styles.inputNotice}>
                 <FaLock size={14} />

--- a/src/layouts/EditCard/Setting/index.tsx
+++ b/src/layouts/EditCard/Setting/index.tsx
@@ -14,8 +14,7 @@ import post from './post.svg'
 
 const creatorNameLocalStorageKey = 'creatorName'
 
-const calcDeliveredAt = () => {
-  const date = new Date()
+const calcDeliveredAt = (date: Date) => {
   if (date.getMonth() === 0) {
     return new Date(date.getFullYear(), 0, date.getDate() + 1, 6)
   }
@@ -35,6 +34,7 @@ const Setting = () => {
 
   useEffect(() => {
     if (!session) return
+    if (creatorName !== undefined) return
     setCreatorName(
       localStorage.getItem(creatorNameLocalStorageKey) ??
         session?.user?.name ??
@@ -61,7 +61,7 @@ const Setting = () => {
   const router = useRouter()
 
   const now = new Date()
-  const deliveredAt = calcDeliveredAt()
+  const deliveredAt = calcDeliveredAt(now)
   const isExpressAvailable = now.getMonth() === 0
 
   const save = () => {

--- a/src/layouts/EditCard/Setting/index.tsx
+++ b/src/layouts/EditCard/Setting/index.tsx
@@ -11,7 +11,7 @@ import postNumber from './post-number.svg'
 import Image from 'next/image'
 import expressLabel from './express-label.svg'
 import post from './post.svg'
-import { FaEye, FaEyeSlash } from 'react-icons/fa6'
+import { FaEarthAmericas, FaLock } from 'react-icons/fa6'
 
 const creatorNameLocalStorageKey = 'creatorName'
 
@@ -128,7 +128,7 @@ const Setting = () => {
                 placeholder="SNS用"
               />
               <div className={styles.inputNotice}>
-                <FaEyeSlash size={16} />
+                <FaLock size={14} />
                 自分にのみ表示されます
               </div>
             </div>
@@ -154,7 +154,7 @@ const Setting = () => {
                 disabled={creatorName === undefined}
               />
               <div className={styles.inputNotice}>
-                <FaEye size={16} />
+                <FaEarthAmericas size={14} />
                 相手に公開されます
               </div>
             </div>

--- a/src/layouts/EditCard/Setting/index.tsx
+++ b/src/layouts/EditCard/Setting/index.tsx
@@ -11,6 +11,7 @@ import postNumber from './post-number.svg'
 import Image from 'next/image'
 import expressLabel from './express-label.svg'
 import post from './post.svg'
+import { FaEye, FaEyeSlash } from 'react-icons/fa6'
 
 const creatorNameLocalStorageKey = 'creatorName'
 
@@ -105,43 +106,57 @@ const Setting = () => {
           <div className={styles.postNumberContainer}>
             <Image src={postNumber} alt="" />
           </div>
-          <div className={styles.inputContainer}>
-            <div className={styles.titleGroup}>
-              <div className={styles.title}>タイトル</div>
-              <div className={styles.error}>
-                {title === undefined || title
-                  ? ''
-                  : 'タイトルを入力してください'}
+          <div className={styles.inputGroup}>
+            <div className={styles.inputContainer}>
+              <div className={styles.titleGroup}>
+                <div className={styles.title}>タイトル</div>
+                <div className={styles.error}>
+                  {title === undefined || title
+                    ? ''
+                    : 'タイトルを入力してください'}
+                </div>
+              </div>
+              <input
+                className={
+                  styles.input[
+                    title === undefined || title ? 'default' : 'error'
+                  ]
+                }
+                value={title ?? ''}
+                onChange={(event) => setTitle(event.target.value)}
+                disabled={title === undefined}
+              />
+              <div className={styles.inputNotice}>
+                <FaEyeSlash size={16} />
+                自分にのみ表示されます
               </div>
             </div>
-            <input
-              className={
-                styles.input[title === undefined || title ? 'default' : 'error']
-              }
-              value={title ?? ''}
-              onChange={(event) => setTitle(event.target.value)}
-              disabled={title === undefined}
-            />
-          </div>
-          <div className={styles.inputContainer}>
-            <div className={styles.titleGroup}>
-              <div className={styles.title}>差出人</div>
-              <div className={styles.error}>
-                {creatorName === undefined || creatorName
-                  ? ''
-                  : '差出人を入力してください'}
+            <div className={styles.inputContainer}>
+              <div className={styles.titleGroup}>
+                <div className={styles.title}>差出人</div>
+                <div className={styles.error}>
+                  {creatorName === undefined || creatorName
+                    ? ''
+                    : '差出人を入力してください'}
+                </div>
+              </div>
+              <input
+                className={
+                  styles.input[
+                    creatorName === undefined || creatorName
+                      ? 'default'
+                      : 'error'
+                  ]
+                }
+                value={creatorName ?? ''}
+                onChange={(event) => setCreatorName(event.target.value)}
+                disabled={creatorName === undefined}
+              />
+              <div className={styles.inputNotice}>
+                <FaEye size={16} />
+                相手に公開されます
               </div>
             </div>
-            <input
-              className={
-                styles.input[
-                  creatorName === undefined || creatorName ? 'default' : 'error'
-                ]
-              }
-              value={creatorName ?? ''}
-              onChange={(event) => setCreatorName(event.target.value)}
-              disabled={creatorName === undefined}
-            />
           </div>
           <div
             className={


### PR DESCRIPTION
機能追加ではなくUIの改善

- 各編集タブの、オブジェクトを選んでいないと押せないボタンを、消すのではなく半透明で無効を表現する
- タイトルとか設定画面に、相手に見えるか書く
- 読み込み中Safariでナビバーが青くなるので直す
- タイトル設定画面でハイドレーションエラーが起きる場合があったので対策する
- テキスト編集ビューでtextareaをオートフォーカスする
- テキスト編集中にiOSの「完了」をクリックしてテキスト編集ビューを閉じる