### PR TITLE
受け取り画面のSafariでのアニメーションのバグを直す

### DIFF
--- a/src/layouts/Shared/index.css.ts
+++ b/src/layouts/Shared/index.css.ts
@@ -249,6 +249,7 @@ export const title = style({
     },
     [`${container.loading} &`]: {
       opacity: 0,
+      transition: 'none',
     },
   },
 })
@@ -274,6 +275,7 @@ export const cardStageContaienr = style({
     },
     [`${container.loading} &`]: {
       opacity: 0,
+      transition: 'none',
     },
   },
 })
@@ -524,6 +526,7 @@ export const controlContainer = style({
   selectors: {
     [`${container.loading} &`]: {
       opacity: 0,
+      transition: 'none',
     },
   },
 })

--- a/src/layouts/Shared/index.css.ts
+++ b/src/layouts/Shared/index.css.ts
@@ -12,6 +12,7 @@ export const container = styleVariants({
   default: [containerBase],
   newArrival: [containerBase],
   loading: [containerBase],
+  revealing: [containerBase],
 })
 
 export const backgroundContainer = style({
@@ -25,12 +26,14 @@ export const backgroundContainer = style({
   gridTemplateRows: '8fr 1fr',
   overflow: 'hidden',
   opacity: 0,
-  transition: 'opacity 0.3s 1s',
 
   selectors: {
     [`${container.newArrival} &`]: {
       opacity: 1,
       transition: 'opacity 0.3s',
+    },
+    [`${container.revealing} &`]: {
+      transition: 'opacity 0.3s 1s',
     },
   },
 })

--- a/src/layouts/Shared/index.tsx
+++ b/src/layouts/Shared/index.tsx
@@ -68,22 +68,31 @@ const Shared = ({
     existingReceivedCard !== undefined &&
       existingReceivedCard.attributes.publishedAt === null
   )
+  const [isAlreadyReceived, setIsAlreadyReceived] = useState<
+    boolean | undefined
+  >(isDelivered ? undefined : false)
 
   useEffect(() => {
     if (isReceived === undefined) {
       if (strapiUserId === cardCreatorId) {
         setSeed(10000000 + Math.floor(Math.random() * 90000000))
         setIsReceived(false)
+        setIsAlreadyReceived(false)
       } else if (existingReceivedCard) {
         setSeed(existingReceivedCard.attributes.randomSeed)
         setIsReceived(existingReceivedCard.attributes.publishedAt !== null)
+        setIsAlreadyReceived(
+          existingReceivedCard.attributes.publishedAt !== null
+        )
       } else {
         getLocalReceivedCard(shareId).then((localReceivedCard) => {
           if (localReceivedCard) {
             setSeed(localReceivedCard.randomSeed)
             setIsReceived(true)
+            setIsAlreadyReceived(true)
           } else {
             setIsReceived(false)
+            setIsAlreadyReceived(false)
           }
         })
       }
@@ -135,6 +144,8 @@ const Shared = ({
               ? 'loading'
               : isDelivered && !isReceived
               ? 'newArrival'
+              : isReceived && !isAlreadyReceived
+              ? 'revealing'
               : 'default'
           ]
         }


### PR DESCRIPTION
- 予約画面、予約済み画面、受け取り済み画面でも、一瞬赤背景が見えることがある
- 受け取り画面、受け取り済み画面で、ロード前に一瞬年賀状などが見える

command + option + R 連打してると再現しやすい