### PR TITLE
ブラウザ判定をホワイトリスト形式に変更

### DIFF
--- a/src/components/LoginButton/Dialog/index.tsx
+++ b/src/components/LoginButton/Dialog/index.tsx
@@ -11,7 +11,7 @@ const Dialog = ({ onClose }: DialogProps) => {
     <div className={styles.screen}>
       <div className={styles.container}>
         <span>
-          アプリ内ブラウザではご利用いただけません。
+          この環境ではご利用いただけません。
           <br />
           SafariやChromeなどの外部ブラウザをご利用ください。
         </span>

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -25,34 +25,34 @@ const LoginButton = ({
   const isInApp = (() => {
     if (!userAgent) return
 
-    const match = userAgent.match(/[^()\[\]\s]+|\([^()]*\)|\[[^\[\]]*\]/g)
-    const items = match
-      ? match.flatMap((item) =>
-          item.startsWith('(') || item.startsWith('[')
-            ? item.slice(1, -1).split(/;\s+/)
-            : item.split(' ')
+    const matches = userAgent.match(/[^()\[\]\s]+|\([^()]*\)|\[[^\[\]]*\]/g)
+    const tokens = matches
+      ? matches.flatMap((match) =>
+          match.startsWith('(') || match.startsWith('[')
+            ? match.slice(1, -1).split(/;\s+/)
+            : match.split(' ')
         )
       : []
 
-    if (items.some((item) => item.startsWith('sleipnir/'))) {
+    if (tokens.some((token) => token.startsWith('sleipnir/'))) {
       // SleipnirはinAppでない
       return false
     }
 
-    if (items.includes('wv')) {
+    if (tokens.includes('wv')) {
       // Sleipnir以外のwvはinApp
       return true
     }
     // Androidはここまでで判定可能
 
     if (
-      items.some(
-        (item) =>
-          item.startsWith('fban/') ||
-          item.startsWith('fb_iab/') ||
-          item.startsWith('line/') ||
-          item === 'instagram' ||
-          item === 'twitter'
+      tokens.some(
+        (token) =>
+          token.startsWith('fban/') ||
+          token.startsWith('fb_iab/') ||
+          token.startsWith('line/') ||
+          token === 'instagram' ||
+          token === 'twitter'
       )
     ) {
       // 含まれていたらinApp
@@ -60,8 +60,8 @@ const LoginButton = ({
     }
 
     if (
-      !items.some(
-        (item) => item.startsWith('safari/') || item.startsWith('firefox/')
+      !tokens.some(
+        (token) => token.startsWith('safari/') || token.startsWith('firefox/')
       )
     ) {
       // 含まれていなければinApp

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -22,29 +22,21 @@ const LoginButton = ({
     () => undefined
   )
 
-  const browser = (() => {
+  const isWebview = (() => {
     if (!userAgent) return
 
-    const isFacebook =
-      userAgent.includes('fbios') || userAgent.includes('fb_iab')
-    const isInstagram = userAgent.includes('instagram')
-    const isLine = userAgent.includes('line/')
-    const isYahoo = userAgent.includes('yjapp')
-    const isTwitter = userAgent.includes('twitter')
-    const isWebview = userAgent.includes('webview') // e.g. Rakuten Link
-    return isFacebook
-      ? 'facebook'
-      : isInstagram
-      ? 'instagram'
-      : isLine
-      ? 'line'
-      : isYahoo
-      ? 'yahoo'
-      : isTwitter
-      ? 'twitter'
-      : isWebview
-      ? 'webview'
-      : 'other'
+    const items = userAgent.split(' ')
+    const lastItem = items[items.length - 1]
+    const browser = lastItem.split('/')[0]
+    return (
+      browser !== 'safari' &&
+      browser !== 'chrome' &&
+      browser !== 'firefox' &&
+      browser !== 'opr' &&
+      browser !== 'edge' &&
+      browser !== 'edg' &&
+      browser !== 'edga'
+    )
   })()
 
   const os = (() => {
@@ -62,7 +54,7 @@ const LoginButton = ({
 
   const [isFirstClick, setIsFirstClick] = useState(true)
 
-  if (browser && browser !== 'other') {
+  if (isWebview) {
     return (
       <Link
         href={`intent://${String(window.location).replace(

--- a/src/layouts/Top/index.css.ts
+++ b/src/layouts/Top/index.css.ts
@@ -104,6 +104,8 @@ export const buttonLayout = style({
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
+  textAlign: 'center',
+  textDecoration: 'none',
 })
 
 export const mainDescription = style({

--- a/src/layouts/pc/Left/index.css.ts
+++ b/src/layouts/pc/Left/index.css.ts
@@ -97,6 +97,7 @@ export const buttonLayout = style({
   cursor: 'pointer',
   width: '320px',
   height: '46px',
+  textDecoration: 'none',
 })
 
 export const bottomInfo = style({


### PR DESCRIPTION
mixi2対応かねて、ブラウザの判定をきっちりやってみる
Androidの場合、`Mozilla/5.0`の後ろの`()`に`wv`が入るとログインできない
それ以外は、スペース区切り最後の塊が`/`で区切られていて、`/`区切り先頭が
Sleipnir (Android)は例外で、`wv` が入るのにログインできる

UA確認メモ
✅…Google OAuth OK
❌…Google OAuth NG

✅Chrome (iOS)
`Mozilla/5.0 (iPhone; CPU iPhone OS 18_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/131.0.6778.154 Mobile/15E148 Safari/604.1`

✅Safari (iOS), Sleipnir (iOS)
`Mozilla/5.0 (iPhone; CPU iPhone OS 18_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0.1 Mobile/15E148 Safari/604.1`

✅Firefox (iOS)
`Mozilla/5.0 (iPhone; CPU iPhone OS 18_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/133.4 Mobile/15E148 Safari/605.1.15`

✅Safari, Chrome (macOS)
`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36`

✅Edge (Windows)
`Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0`

✅Chrome (Windows)
`Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36`

✅Firefox (Windows)
`Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:131.0) Gecko/20100101 Firefox/131.0`

✅Edge (Android)
`Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36`

✅Sleipnir (Android)
`Mozilla/5.0 (Linux; Android 13; M2101K9R Build/TKQ1.220829.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.136 Mobile Safari/537.36 Sleipnir/3.7.7`

✅Firefox (Android)
`Mozilla/5.0 (Android 13; Mobile; rv:133.0) Gecko/133.0 Firefox/133.0`

✅Opera (Android)
`Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Mobile Safari/537.36 OPR/86.0.0.0`

✅Brave (Android), Vivaldi (Android)
`Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36`

❌Facebook (iOS)
`Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16A366 [FBAN/FBIOS;FBDV/iPhone10,3;FBMD/iPhone;FBSN/iOS;FBSV/12.0;FBSS/3;FBCR/KDDI;FBID/phone;FBLC/ja_JP;FBOP/5;FBRV/128068097]`

❌Facebook (Android)
`Mozilla/5.0 (Linux; Android 11; Pixel 4 Build/RQ2A.210405.005; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/90.0.4430.210 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/324.0.0.48.120;]`

❌Instagram (Android)
`Mozilla/5.0 (Linux; Android 13; M2101K9R Build/TKQ1.220829.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.136 Mobile Safari/537.36 Instagram 361.0.0.46.88 Android (33/13; 440dpi; 1080x2252; Xiaomi; M2101K9R; renoir; qcom; ja_JP; 674675147)`

❌mixi2 (Android)
`Mozilla/5.0 (Linux; Android 13; M2101K9R Build/TKQ1.220829.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.136 Mobile Safari/537.36`

❌mixi2 (iOS)
`Mozilla/5.0 (iPhone; CPU iPhone OS 18_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148`

❌Instagram (iOS)
`Mozilla/5.0 (iPhone; CPU iPhone OS 18_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/22A3370 Instagram 361.0.0.35.82 (iPhone16,1; iOS 18_0_1; ja_JP; ja; scale=3.00; 1179x2556; 674117118; IABMV/1) NW/3`

❌LINE (iOS)
`Mozilla/5.0 (iPhone; CPU iPhone OS 18_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Safari Line/14.21.0`

❌Rakuten Link (Android)
`Mozilla/5.0 (Linux; Android 14; XIG03 Build/UKQ1.230917.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.135 Mobile Safari/537.36 LinkWebview Link Android App-jp.co.rakuten.mobile.rcs/3.0.2`